### PR TITLE
Make /var/lib/nginx dir writable for error logs

### DIFF
--- a/apko.yaml
+++ b/apko.yaml
@@ -21,6 +21,11 @@ paths:
     uid: 10000
     gid: 10000
     permissions: 0o755
+  - path: /var/lib/nginx
+    type: directory
+    uid: 10000
+    gid: 10000
+    permissions: 0o755
 
 entrypoint:
   type: service-bundle


### PR DESCRIPTION
Currently seeing
```
docker run distroless.dev/nginx

nginx: [alert] could not open error log file: open() "/var/lib/nginx/logs/error.log" failed (13: Permission denied)
2022/07/07 14:56:35 [emerg] 8#8: mkdir() "/var/lib/nginx/tmp/client_body" failed (13: Permission denied)
```
Signed-off-by: Priya Wadhwa <priya@chainguard.dev>