### PR TITLE
Create a tag for the nginx version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: sigstore/cosign-installer@main
+    - uses: mikefarah/yq@v4.25.3
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2.0.0
@@ -40,12 +41,19 @@ jobs:
         empty-workspace: true
         archs: x86_64,aarch64,armv7
 
+    - name: Get nginx version
+      id: nginx-version
+      run: |
+        nginx_version=$(yq '.package.version' melange.yaml)
+        echo '::set-output name=nginx_version::$nginx_version'
+
     - uses: distroless/actions/apko-snapshot@main
       with:
         config: apko.yaml
         base-tag: ghcr.io/${{ github.repository }}
         keyring-append: /github/workspace/melange.rsa.pub
         archs: x86_64,aarch64,armv7
+        additional-tags: ${{ steps.nginx-version.outputs.nginx_version }}
 
     - if: ${{ failure() }}
       uses: rtCamp/action-slack-notify@v2.2.0

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ If you'd like to see other architectures supported, please file an issue!
 
 ## Usage
 
+The image is available at the following tags:
+
+```
+docker pull distroless.dev/nginx:latest # Latest, build from head
+docker pull distroless.dev/nginx:[nginx version] # Pull at a specific version
+```
+
+Currently nginx version 1.20.2 is supported.
+
+## Try it Out
+
+
 To try out the image, run:
 
 ```


### PR DESCRIPTION
Tag the nginx image with the nginx version. This will be replaced every day until the version changes.  Will create `gcr.io/distroless/nginx:1.20.2`

Depends on https://github.com/distroless/actions/pull/21 to merge first

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

closes https://github.com/distroless/nginx/issues/8